### PR TITLE
[fix] removed unwanted repeated url from env

### DIFF
--- a/vehicle-tracker/vehicle_tracker_app/.env
+++ b/vehicle-tracker/vehicle_tracker_app/.env
@@ -1,7 +1,4 @@
 API_URL=http://167.71.225.156:8080/api/v3
 UNIFIED_DEV_API_URL=https://unified-dev.digit.org
-LOCALIZATION_API_URL=https://unified-dev.digit.org/localization/messages/v1/_search
-OPERATOR_ID_URL=https://unified-dev.digit.org/vendor/driver/v1/_search
 MDMS_URL=https://raw.githubusercontent.com/egovernments/egov-mdms-data/UNIFIED-DEV/data/pb/common-masters/StateInfo.json
-LOGIN_URL=https://unified-dev.digit.org/user/oauth/token
 PERIODIC_TRACKING_FREQUENCY=10

--- a/vehicle-tracker/vehicle_tracker_app/lib/blocs/login/controllers/login_controllers.dart
+++ b/vehicle-tracker/vehicle_tracker_app/lib/blocs/login/controllers/login_controllers.dart
@@ -9,7 +9,6 @@ import 'package:vehicle_tracker_app/util/i18n_translations.dart';
 class LoginController extends GetxController {
   TextEditingController userNameController = TextEditingController();
   TextEditingController passwordController = TextEditingController();
-  final url = loginUrl;
   String city = cities.keys.first;
 
   void login(context) async {

--- a/vehicle-tracker/vehicle_tracker_app/lib/blocs/login/repository/login_http_reposotry.dart
+++ b/vehicle-tracker/vehicle_tracker_app/lib/blocs/login/repository/login_http_reposotry.dart
@@ -15,6 +15,8 @@ import '../../../util/toaster.dart';
 class LoginHTTPRepository {
   static Future<bool> login(BuildContext context, String username, String password, String city) async {
     try {
+      final loginUrl = "$unifiedDevApiUrl/user/oauth/token";
+
       Map<String, dynamic> formData = {
         "grant_type": "password",
         "scope": "read",
@@ -60,7 +62,8 @@ class LoginHTTPRepository {
   }
 
   static Future<String> getDriverId(String authToken, String uuid, String tenantId) async {
-    final url = "$unifiedDevApiUrl/vendor/driver/v1/_search?tenantId=$tenantId&ownerIds=$uuid";
+    final url = "$unifiedDevApiUrl/vendor/driver/v1/_search";
+    final loginUrl = "$url?tenantId=$tenantId&ownerIds=$uuid";
 
     Map<String, dynamic> body = {
       "RequestInfo": {
@@ -69,7 +72,7 @@ class LoginHTTPRepository {
       }
     };
 
-    final response = await HttpService.postRequest(url, body);
+    final response = await HttpService.postRequest(loginUrl, body);
     if (response.statusCode != 200) {
       log("Error in getting driver id : ${response.statusCode}");
       return "";

--- a/vehicle-tracker/vehicle_tracker_app/lib/constants.dart
+++ b/vehicle-tracker/vehicle_tracker_app/lib/constants.dart
@@ -3,11 +3,8 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 final String apiUrl = dotenv.env["API_URL"] ?? "";
-final String localizationUrl = dotenv.env["LOCALIZATION_API_URL"] ?? "";
 final String mdmsUrl = dotenv.env["MDMS_URL"] ?? "";
-final String loginUrl = dotenv.env["LOGIN_URL"] ?? "";
 final int periodicTrackingFrequency = int.parse(dotenv.env["PERIODIC_TRACKING_FREQUENCY"] ?? "10");
-final String operatorIdUrl = dotenv.env["OPERATOR_ID_URL"] ?? "";
 final String unifiedDevApiUrl = dotenv.env["UNIFIED_DEV_API_URL"] ?? "";
 
 const Map<String, String> cities = {

--- a/vehicle-tracker/vehicle_tracker_app/lib/data/localization_service.dart
+++ b/vehicle-tracker/vehicle_tracker_app/lib/data/localization_service.dart
@@ -78,6 +78,7 @@ class LocalizationService {
 
   // get localization from API
   static Future<List<LocalizationMessageModel>?> getLocalicationFromAPI(String locale) async {
+    final localizationUrl = "$unifiedDevApiUrl/localization/messages/v1/_search";
     final url = "$localizationUrl?module=rainmaker-fsm&locale=$locale&tenantId=pb.amritsar";
 
     Map<String, dynamic> body = {


### PR DESCRIPTION
A lot of URLs where just modifications of unified_dev_url in `.env` so it needed to be removed. Now the app uses the common URL and add parameters to it as required.